### PR TITLE
Add missing dependencies to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,15 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.6</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.8.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_2.12</artifactId>
+            <version>2.9.0</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Kafkastats was complaining about:
Exception in thread "main" java.lang.NoClassDefFoundError: com/fasterxml/jackson/annotation/JsonMerge

so add jackson-core 2.8.9 as dependecy.

Also update jackson-module-scala_2.12 to 2.9.0 because of:
Exception in thread "main" com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.8.4 requires Jackson Databind version >= 2.8.0 and < 2.9.0

The software does compile and start even though the dependncies are off,
but it doesn't really work (it cannot parse ZK responses etc. so it
keeps running and logging errors).