### PR TITLE
Fix parsing issues if logdirs contain commas

### DIFF
--- a/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
+++ b/kafkastats/src/main/java/com/pinterest/doctorkafka/stats/BrokerStatsRetriever.java
@@ -397,7 +397,7 @@ public class BrokerStatsRetriever {
     String brokerIdStr = kafkaProperties.getProperty("broker.id");
     if (brokerIdStr == null) {
       // load from $kafka_log_dir/meta.properties
-      String logDirsStr = kafkaProperties.getProperty("log.dirs");
+      String logDirsStr = kafkaProperties.getProperty("log.dirs").split(",")[0];
       kafkaProperties.load(new FileInputStream(logDirsStr + "/meta.properties"));
       brokerIdStr = kafkaProperties.getProperty("broker.id");
     }


### PR DESCRIPTION
Kafka supports specifying multiple log dirs separated with commas. This
commit fixes that issue where user might have specified multiple log
dirs.

Kafka writes the meta.properties to all log dirs, so it's safe to assume
that if we take the first one it'll be good enough.